### PR TITLE
Frontend/mergetableview

### DIFF
--- a/watomate/Watomate/Sources/CalendarHeaderView.swift
+++ b/watomate/Watomate/Sources/CalendarHeaderView.swift
@@ -104,7 +104,7 @@ class CalendarHeaderView: UITableViewHeaderFooterView {
         return stackView
     }()
     
-    private lazy var calendarView: UICalendarView = {
+    lazy var calendarView: UICalendarView = {
         var view = UICalendarView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.wantsDateDecorations = true
@@ -124,13 +124,5 @@ class CalendarHeaderView: UITableViewHeaderFooterView {
             profileIntro.text = "프로필에 자기소개를 입력해보세요"
         }
         profileImageContainer.setProfileImage()
-    }
-    
-    fileprivate func setCalendar() {
-//        calendarView.delegate = self
-//
-//        let dateSelection = UICalendarSelectionSingleDate(delegate: self)
-//        calendarView.selectionBehavior = dateSelection
-        calendarView.fontDesign = .rounded
     }
 }

--- a/watomate/Watomate/Sources/CalendarHeaderView.swift
+++ b/watomate/Watomate/Sources/CalendarHeaderView.swift
@@ -10,12 +10,124 @@ import UIKit
 
 class CalendarHeaderView: UITableViewHeaderFooterView {
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
-    }
-    */
+    static let reuseIdentifier = "CalendarHeaderView"
+    
+    var emoji = "no emoji"
 
+    
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupLayout() {
+        addSubview(headerStackView)
+        headerStackView.snp.makeConstraints { make in
+            make.leading.trailing.equalTo(self.safeAreaLayoutGuide).inset(16)
+            make.top.bottom.equalTo(self.safeAreaLayoutGuide)
+        }
+        profileImageContainer.snp.makeConstraints { make in
+            make.height.width.equalTo(60)
+        }
+    }
+    
+    private lazy var statusView: UIStackView = {
+        var stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        stackView.alignment = .center
+        stackView.addArrangedSubview(profileImageContainer)
+        stackView.addArrangedSubview(profileLabelStackView)
+        stackView.addArrangedSubview(diaryButton)
+        return stackView
+    }()
+    
+    private lazy var profileImageContainer: UIImageView = {
+        let imageView = UIImageView(image: UIImage(systemName: "gearshape"))
+        imageView.backgroundColor = .gray
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.layer.cornerRadius = ProfileImageConstant.thumbnailSize / 2.0
+        imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        return imageView
+    }()
+    
+    private lazy var profileLabelStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = 4
+        stackView.addArrangedSubview(profileName)
+        stackView.addArrangedSubview(profileIntro)
+        stackView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        return stackView
+    }()
+    
+    private lazy var profileName: UILabel = {
+        var label = UILabel()
+        label.text = "test username"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var profileIntro: UILabel = {
+        var label = UILabel()
+        label.text = "프로필에 자기소개를 입력해보세요"
+        label.font = UIFont.systemFont(ofSize: 12)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    lazy var diaryButton : UIButton = {
+        let button = UIButton(type: .system)
+//        button.addTarget(self, action: #selector(diaryButtonTapped), for: .touchUpInside)
+        button.setImage(UIImage(systemName: "face.dashed"), for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        return button
+    }()
+    
+    private lazy var headerStackView: UIStackView = {
+        var stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 10
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(statusView)
+        stackView.addArrangedSubview(calendarView)
+        return stackView
+    }()
+    
+    private lazy var calendarView: UICalendarView = {
+        var view = UICalendarView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.wantsDateDecorations = true
+        return view
+    }()
+    
+    func setDiaryBtnAction(target: Any?, action: Selector, for event: UIControl.Event) {
+        diaryButton.addTarget(target, action: action, for: event)
+    }
+    
+    func updateUserInfo(with homeViewModel: HomeViewModel){
+        // let profileImageUrl = URL(string: homeViewModel.user?.profile_pic)
+        // profileImage.kf.setImage(with: profileImageUrl)
+        // kingfisher no such module error
+        profileName.text = homeViewModel.user?.username
+        profileIntro.text = homeViewModel.user?.intro
+        
+        // followingProfileName.text = "following user name"
+        // followingProfileImage.image = UIImage(named: "waffle.jpg")
+    }
+    
+    fileprivate func setCalendar() {
+//        calendarView.delegate = self
+//
+//        let dateSelection = UICalendarSelectionSingleDate(delegate: self)
+//        calendarView.selectionBehavior = dateSelection
+        calendarView.fontDesign = .rounded
+    }
 }

--- a/watomate/Watomate/Sources/CalendarHeaderView.swift
+++ b/watomate/Watomate/Sources/CalendarHeaderView.swift
@@ -7,6 +7,8 @@
 //
 
 import UIKit
+import SnapKit
+import Kingfisher
 
 class CalendarHeaderView: UITableViewHeaderFooterView {
 
@@ -47,13 +49,16 @@ class CalendarHeaderView: UITableViewHeaderFooterView {
         return stackView
     }()
     
-    private lazy var profileImageContainer: UIImageView = {
-        let imageView = UIImageView(image: UIImage(systemName: "gearshape"))
-        imageView.backgroundColor = .gray
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.layer.cornerRadius = ProfileImageConstant.thumbnailSize / 2.0
+    private lazy var profileImageContainer: SymbolCircleView = {
+        let imageView = SymbolCircleView(symbolImage: UIImage(systemName: "person.fill"))
+        imageView.setBackgroundColor(.secondarySystemFill)
         imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         return imageView
+    }()
+    
+    private lazy var profileImage: UIImage = {
+        let image = UIImage()
+        return image
     }()
     
     private lazy var profileLabelStackView: UIStackView = {
@@ -76,7 +81,6 @@ class CalendarHeaderView: UITableViewHeaderFooterView {
     
     private lazy var profileIntro: UILabel = {
         var label = UILabel()
-        label.text = "프로필에 자기소개를 입력해보세요"
         label.font = UIFont.systemFont(ofSize: 12)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -84,7 +88,6 @@ class CalendarHeaderView: UITableViewHeaderFooterView {
     
     lazy var diaryButton : UIButton = {
         let button = UIButton(type: .system)
-//        button.addTarget(self, action: #selector(diaryButtonTapped), for: .touchUpInside)
         button.setImage(UIImage(systemName: "face.dashed"), for: .normal)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setContentHuggingPriority(.defaultHigh, for: .horizontal)
@@ -112,15 +115,15 @@ class CalendarHeaderView: UITableViewHeaderFooterView {
         diaryButton.addTarget(target, action: action, for: event)
     }
     
-    func updateUserInfo(with homeViewModel: HomeViewModel){
-        // let profileImageUrl = URL(string: homeViewModel.user?.profile_pic)
-        // profileImage.kf.setImage(with: profileImageUrl)
-        // kingfisher no such module error
-        profileName.text = homeViewModel.user?.username
-        profileIntro.text = homeViewModel.user?.intro
-        
-        // followingProfileName.text = "following user name"
-        // followingProfileImage.image = UIImage(named: "waffle.jpg")
+    func setupUserInfo() {
+        profileName.text = User.shared.username
+        let intro = User.shared.intro
+        if intro?.isEmpty == false {
+            profileIntro.text = intro
+        } else {
+            profileIntro.text = "프로필에 자기소개를 입력해보세요"
+        }
+        profileImageContainer.setProfileImage()
     }
     
     fileprivate func setCalendar() {

--- a/watomate/Watomate/Sources/CalendarHeaderView.swift
+++ b/watomate/Watomate/Sources/CalendarHeaderView.swift
@@ -41,7 +41,7 @@ class CalendarHeaderView: UITableViewHeaderFooterView {
         var stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
-        stackView.spacing = 10
+        stackView.spacing = 14
         stackView.alignment = .center
         stackView.addArrangedSubview(profileImageContainer)
         stackView.addArrangedSubview(profileLabelStackView)

--- a/watomate/Watomate/Sources/CalendarHeaderView.swift
+++ b/watomate/Watomate/Sources/CalendarHeaderView.swift
@@ -1,0 +1,21 @@
+//
+//  CalendarHeaderView.swift
+//  Watomate
+//
+//  Created by 권현구 on 1/30/24.
+//  Copyright © 2024 tuist.io. All rights reserved.
+//
+
+import UIKit
+
+class CalendarHeaderView: UITableViewHeaderFooterView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/watomate/Watomate/Sources/HomeViewController.swift
+++ b/watomate/Watomate/Sources/HomeViewController.swift
@@ -1,0 +1,30 @@
+//
+//  HomeViewController.swift
+//  Watomate
+//
+//  Created by 권현구 on 1/30/24.
+//  Copyright © 2024 tuist.io. All rights reserved.
+//
+
+import UIKit
+
+class HomeViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/watomate/Watomate/Sources/HomeViewController.swift
+++ b/watomate/Watomate/Sources/HomeViewController.swift
@@ -8,23 +8,215 @@
 
 import UIKit
 
-class HomeViewController: UIViewController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+class HomeViewController: TodoTableViewController {
+    var diaryViewModel = DiaryPreviewViewModel()
+    var homeViewModel = HomeViewModel()
+    lazy var userID = User.shared.id
+    var selectedDate: DateComponents? = nil
+    
+    private lazy var logoImage : UIImageView = {
+        var view = UIImageView()
+        view.image = UIImage(systemName: "gearshape") // 추후 최종 로고 이미지로 변경
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private lazy var notificationButton : UIBarButtonItem = {
+        let button = UIBarButtonItem(image: UIImage(systemName: "bell"))
+        // button.addTarget(self, action: #selector(notificationButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    private lazy var showmoreButton : UIBarButtonItem = {
+        let button = UIBarButtonItem(systemItem: .action)
+        // button.addTarget(self, action: #selector(notificationButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    private lazy var followingStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        stackView.backgroundColor = .gray
+        return stackView
+    }()
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: true)
+        setupTopBarItems()
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewDidLoad() {
+        todoTableView.register(CalendarHeaderView.self, forHeaderFooterViewReuseIdentifier: CalendarHeaderView.reuseIdentifier)
+        super.viewDidLoad()
+        guard let userID else { return }
+        getHomeUser(userID: userID)
+//        setCalendar()
     }
-    */
+    override func setupLayout() {
+        //TODO: add following/follower info, tedoori
+        logoImage.snp.makeConstraints { make in
+            make.height.width.equalTo(30)
+        }
+        
+        view.addSubview(followingStackView)
+        followingStackView.snp.makeConstraints { make in
+            make.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            make.height.equalTo(100)
+        }
+        
+        view.addSubview(todoTableView)
+        todoTableView.snp.makeConstraints { make in
+            make.top.equalTo(followingStackView.snp.bottom).offset(10)
+            make.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+    
+    private func setupTopBarItems() {
+        self.navigationItem.rightBarButtonItems = [showmoreButton, notificationButton]
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: logoImage)
+    }
+    
+    func getHomeUser(userID: Int) {
+        homeViewModel.getHomeUser(userID: userID) {
+            DispatchQueue.main.async { [weak self] in
+//                self?.updateUserInfo()
+                self?.updateUserTedoori()
+            }
+        }
+    }
 
+    private func updateUserTedoori(){
+        if homeViewModel.user?.tedoori == true{
+//            profileImageContainer.layer.borderWidth =  TedooriConstants.outerBorderWidth
+//            profileImageContainer.layer.borderColor = TedooriConstants.outerBorderColor.cgColor
+//            profileImage.layer.borderWidth = TedooriConstants.innerBorderWidth
+//            profileImage.layer.borderColor = TedooriConstants.innerBorderColor.cgColor
+        }
+        else{
+//            profileImageContainer.layer.borderWidth =  0
+//            profileImage.layer.borderWidth = 0
+        }
+    } // todo 상태 바뀔 때마다 updateusertedoori 불러와야 함
+
+    private var diaryDateString: String = {
+        return Utils.YYYYMMddFormatter().string(from: Date())
+    }()
+    
+    var emoji = "no emoji"
+    @objc func diaryButtonTapped() {
+        if emoji == "no emoji" {
+             let diaryCreateVC = DiaryCreateViewController()
+             diaryCreateVC.receivedDateString = diaryDateString
+             diaryCreateVC.existence = false
+             diaryCreateVC.completionClosure = { receivedValue in
+                 self.emoji = receivedValue
+                 self.updateDiaryButtonAppearance()
+             }
+            diaryCreateVC.userName = homeViewModel.user?.username
+            diaryCreateVC.userProfile = homeViewModel.user?.profile_pic
+            diaryCreateVC.hidesBottomBarWhenPushed = true //tabBar 숨기기
+            navigationController?.pushViewController(diaryCreateVC, animated: false)
+        }
+        else{
+            let diaryPreviewVC = DiaryPreviewViewController()
+            diaryPreviewVC.receivedDateString = diaryDateString
+            diaryPreviewVC.userName = homeViewModel.user?.username
+            diaryPreviewVC.userProfile = homeViewModel.user?.profile_pic
+            setSheetLayout(for: diaryPreviewVC)
+            diaryPreviewVC.delegate = self
+            present(diaryPreviewVC, animated: true, completion: nil)
+        }
+   }
+    
+    private func updateDiaryButtonAppearance() {
+        let headerView = tableView(todoTableView, viewForHeaderInSection: 0) as! CalendarHeaderView
+        let diaryButton = headerView.diaryButton
+        if emoji == "no emoji" {
+            diaryButton.setTitle(nil, for: .normal)
+            diaryButton.setImage(UIImage(systemName: "face.dashed"), for: .normal)
+        } else {
+            diaryButton.setImage(nil, for: .normal)
+            diaryButton.setTitle(emoji, for: .normal)
+        }
+    }
+    
+    
+
+    
+    private func reloadCalendarView(date: Date?) {
+       if date == nil { return }
+       let calendar = Calendar.current
+//       calendarView.reloadDecorations(forDateComponents: [calendar.dateComponents([.day, .month, .year], from: date!)], animated: true)
+    }
+    
+    private func getStringToDate(strDate: String) -> Date {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = NSTimeZone(name: "Ko_KR") as TimeZone?
+        
+        return dateFormatter.date(from: strDate)!
+    } //UICalendar은 date형 데이터 사용 : string -> date 형변환 함수
+    
+    
+    let dummy_day = "2024-01-13"
+    private lazy var dummy_days = [getStringToDate(strDate: dummy_day) : [1, "green"]] // [남은 일의 수, 목표 색]
+    
+    private lazy var todoView : UITableView = {
+        var tableView = UITableView()
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        return tableView
+    }()
+}
+
+extension HomeViewController {
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        if section == 0 {
+            guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: CalendarHeaderView.reuseIdentifier) as? CalendarHeaderView else { return nil }
+            header.contentView.backgroundColor = .systemBackground
+            header.setDiaryBtnAction(target: self, action: #selector(diaryButtonTapped), for: .touchUpInside)
+            return header
+        }
+        guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TodoHeaderView.reuseIdentifier) as? TodoHeaderView else { return nil }
+        header.goalView.tag = section
+        header.setTitle(with: todoListViewModel.getTitle(of: section))
+        header.setColor(with: todoListViewModel.getColor(of: section))
+        header.setVisibility(with: todoListViewModel.getVisibility(of: section))
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(addEmptyTodo))
+        header.goalView.addGestureRecognizer(tapGesture)
+        header.goalView.isUserInteractionEnabled = true
+        header.contentView.backgroundColor = .systemBackground
+        return header
+    }
+    
+    override func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        if section == 0 {
+            return 400
+        }
+        return 60
+    }
+}
+
+
+
+
+
+
+extension HomeViewController: DiaryPreviewViewControllerDelegate {
+    func diaryPreviewViewControllerDidRequestDiaryCreation(_ controller: DiaryPreviewViewController) {
+        controller.dismiss(animated: true) {
+            let diaryCreateVC = DiaryCreateViewController()
+            diaryCreateVC.receivedDateString = self.diaryDateString
+            diaryCreateVC.userName = self.homeViewModel.user?.username
+            diaryCreateVC.userProfile = self.homeViewModel.user?.profile_pic
+            diaryCreateVC.existence = true
+            diaryCreateVC.completionClosure = { receivedValue in
+                self.emoji = receivedValue
+                self.updateDiaryButtonAppearance()
+            }
+            diaryCreateVC.hidesBottomBarWhenPushed = true //tabBar 숨기기
+            self.navigationController?.pushViewController(diaryCreateVC, animated: false)
+        }
+    }
 }

--- a/watomate/Watomate/Sources/Mainpage/UI/Diary/DiaryCreateViewController.swift
+++ b/watomate/Watomate/Sources/Mainpage/UI/Diary/DiaryCreateViewController.swift
@@ -39,7 +39,6 @@ class DiaryCreateViewController: PlainCustomBarViewController{
         navigationController?.popViewController(animated: true)
     }
 
-
     func getDiary(userID: Int, date: String) {
         viewModel.getDiary(userID: userID, date: date) {
             DispatchQueue.main.async { [weak self] in
@@ -89,37 +88,40 @@ class DiaryCreateViewController: PlainCustomBarViewController{
     }
     
     private func setupLayout(){
-        contentView.addSubview(emojiView)
+        contentView.addSubview(diaryStackView)
+        diaryStackView.snp.makeConstraints { make in
+            make.edges.equalTo(contentView.safeAreaLayoutGuide).inset(16)
+        }
         emojiView.snp.makeConstraints { make in
-            make.top.equalToSuperview()
-            make.centerX.equalToSuperview()
-            make.height.equalToSuperview().multipliedBy(0.15)
-         }
-        contentView.addSubview(moodView)
+            make.height.equalTo(40)
+        }
         moodView.snp.makeConstraints { make in
-            make.top.equalTo(emojiView.snp.bottom).inset(36)
-            make.centerX.equalToSuperview()
-            make.height.equalToSuperview().multipliedBy(0.05)
-         }
-        
-        contentView.addSubview(profileView)
-        profileView.snp.makeConstraints { make in
-            make.top.equalTo(moodView.snp.bottom).offset(20)
-            make.leading.trailing.equalToSuperview().inset(8)
-            make.height.equalToSuperview().multipliedBy(0.08)
-         }
-        contentView.addSubview(diaryTextField)
+            make.height.equalTo(40)
+        }
+        profileImage.snp.makeConstraints { make in
+            make.height.width.equalTo(60)
+        }
+        infoStackView.snp.makeConstraints { make in
+            make.height.equalTo(60)
+        }
+        nameDateStackView.snp.makeConstraints { make in
+            make.height.equalTo(50)
+        }
+        visibilityButton.snp.makeConstraints { make in
+            make.width.equalTo(90)
+        }
         diaryTextField.snp.makeConstraints { make in
-            make.top.equalTo(profileView.snp.bottom).offset(24)
-            make.leading.trailing.equalToSuperview().inset(16)
-            make.height.equalToSuperview().multipliedBy(0.6)
-         }
-        contentView.addSubview(diaryMenuView)
+            make.height.equalTo(200)
+        }
         diaryMenuView.snp.makeConstraints { make in
-            make.top.equalTo(diaryTextField.snp.bottom)
-            make.leading.trailing.bottom.equalToSuperview()
-         }
-        
+            make.height.equalTo(40)
+        }
+        backgroundColorButton.snp.makeConstraints { make in
+            make.height.width.equalTo(40)
+        }
+        moodButton.snp.makeConstraints { make in
+            make.height.width.equalTo(40)
+        }
     }
     
     func setupProfile() {
@@ -147,6 +149,19 @@ class DiaryCreateViewController: PlainCustomBarViewController{
             emojiView.titleLabel?.font = UIFont.systemFont(ofSize: 36)
         }
     }
+    
+    private lazy var diaryStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 16
+        stackView.distribution = .fill
+        stackView.addArrangedSubview(emojiView)
+        stackView.addArrangedSubview(moodView)
+        stackView.addArrangedSubview(infoStackView)
+        stackView.addArrangedSubview(diaryTextField)
+        stackView.addArrangedSubview(diaryMenuView)
+        return stackView
+    }()
     
     private lazy var emojiView: UIButton = {
         let button = UIButton(type: .system)
@@ -180,46 +195,38 @@ class DiaryCreateViewController: PlainCustomBarViewController{
         var label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.boldSystemFont(ofSize: 24)
+        label.textAlignment = .center
         label.contentMode = .top
         return label
     }()
     
-    private lazy var profileView: UIView = {
-        var view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(profileImage)
-        view.addSubview(profileName)
-        view.addSubview(profileDate)
-        view.addSubview(visibilityButton)
-        profileImage.snp.makeConstraints { make in
-            make.top.bottom.equalToSuperview() //추후 프로필 이미지 사이즈에 따라 변형
-            make.leading.equalToSuperview()
-            make.width.equalTo(view.snp.height)
-         }
-        profileName.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(8)
-            make.leading.equalTo(profileImage.snp.trailing).offset(4)
-         }
-        profileDate.snp.makeConstraints { make in
-            make.bottom.equalToSuperview().inset(8)
-            make.top.equalTo(profileName.snp.bottom)
-            make.leading.equalTo(profileImage.snp.trailing).offset(4)
-         }
-        visibilityButton.snp.makeConstraints { make in
-            make.bottom.equalToSuperview().inset(8)
-            make.leading.equalTo(profileDate.snp.trailing).offset(16)
-            make.width.equalToSuperview().multipliedBy(0.2)
-         }
-        return view
-    }()
-    
     var userProfile : String?
+    
+    private lazy var infoStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        stackView.alignment = .center
+        stackView.addArrangedSubview(profileImage)
+        stackView.addArrangedSubview(nameDateStackView)
+        return stackView
+    }()
     
     private lazy var profileImage : SymbolCircleView = {
         let imageView = SymbolCircleView(symbolImage: UIImage(systemName: "person.fill"))
         imageView.setBackgroundColor(.secondarySystemFill)
         imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         return imageView
+    }()
+    
+    private lazy var nameDateStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 2
+        stackView.alignment = .leading
+        stackView.addArrangedSubview(profileName)
+        stackView.addArrangedSubview(dateVisibilityStackView)
+        return stackView
     }()
     
     var userName : String?
@@ -233,6 +240,17 @@ class DiaryCreateViewController: PlainCustomBarViewController{
     }()
     
     var receivedDateString: String?
+    
+    private lazy var dateVisibilityStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        stackView.alignment = .center
+        stackView.addArrangedSubview(profileDate)
+        stackView.addArrangedSubview(visibilityButton)
+        return stackView
+    }()
+    
     lazy var profileDate: UILabel = {
         var label = UILabel()
         label.text = receivedDateString
@@ -240,6 +258,31 @@ class DiaryCreateViewController: PlainCustomBarViewController{
         label.font = UIFont.systemFont(ofSize: 14)
         
         return label
+    }()
+    
+    private lazy var visibilityButton : UIButton = {
+        let button = UIButton(type: .system)
+        button.addTarget(self, action: #selector(visibilityButtonTapped), for: .touchUpInside)
+        button.backgroundColor = .systemGray4
+        button.setTitle("공개 설정", for: .normal)
+        button.setTitleColor(.black, for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 12)
+        button.titleEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.layer.cornerRadius = 10
+        return button
+    }()
+
+    
+    lazy var diaryTextField: UITextField = {
+        var view = UITextField()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.placeholder = "오늘은 어떤 하루였나요?" // 00님의 오늘은 어떤 하루였나요? <- 00에 이름
+        view.contentVerticalAlignment = .top
+        view.autocorrectionType = .no
+        view.spellCheckingType = .no
+        view.setContentHuggingPriority(.defaultLow, for: .vertical)
+        return view
     }()
     
     var diaryVisibility: DiaryVisibility? = nil
@@ -265,30 +308,6 @@ class DiaryCreateViewController: PlainCustomBarViewController{
         }
     }
     
-    private lazy var visibilityButton : UIButton = {
-        let button = UIButton(type: .system)
-        button.addTarget(self, action: #selector(visibilityButtonTapped), for: .touchUpInside)
-        button.backgroundColor = .systemGray4
-        button.setTitle("공개 설정", for: .normal)
-        button.setTitleColor(.black, for: .normal)
-        button.titleLabel?.font = UIFont.systemFont(ofSize: 12)
-        button.titleEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.layer.cornerRadius = 10
-        return button
-    }()
-
-    
-    lazy var diaryTextField: UITextField = {
-        var view = UITextField()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.placeholder = "오늘은 어떤 하루였나요?" // 00님의 오늘은 어떤 하루였나요? <- 00에 이름
-        view.contentVerticalAlignment = .top
-        view.autocorrectionType = .no
-        view.spellCheckingType = .no
-        return view
-    }()
-    
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         return !(touch.view is UITableView)
     }
@@ -300,21 +319,17 @@ class DiaryCreateViewController: PlainCustomBarViewController{
         }
     }
     
-    private lazy var diaryMenuView: UIView = {
-        var view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(backgroundColorButton)
-        backgroundColorButton.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(8)
-            make.leading.equalToSuperview().offset(16)
-         }
-        view.addSubview(moodButton)
-        moodButton.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(8)
-            make.leading.equalTo(backgroundColorButton.snp.trailing).offset(8)
-         }
-        return view
-        
+    private lazy var diaryMenuView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        stackView.addArrangedSubview(backgroundColorButton)
+        stackView.addArrangedSubview(moodButton)
+        let emptyView = UIView()
+        emptyView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        stackView.addArrangedSubview(emptyView)
+        return stackView
     }()
     
     private lazy var backgroundColorButton: UIButton = {
@@ -355,7 +370,6 @@ class DiaryCreateViewController: PlainCustomBarViewController{
             contentView.backgroundColor = .systemBackground
         } else {
             setBackgroundColor(UIColor(named: backgroundColor ?? "system") ?? .systemBackground)
-            diaryMenuView.backgroundColor = .systemBackground
         }
     }
 

--- a/watomate/Watomate/Sources/Mainpage/UI/Diary/DiaryCreateViewController.swift
+++ b/watomate/Watomate/Sources/Mainpage/UI/Diary/DiaryCreateViewController.swift
@@ -122,6 +122,11 @@ class DiaryCreateViewController: PlainCustomBarViewController{
         
     }
     
+    func setupProfile() {
+        profileName.text = User.shared.username
+        profileImage.setProfileImage()
+    }
+    
     var emoji : String? = nil
     @objc private func emojiButtonTapped() {
         let vc = EmojiViewController()
@@ -209,13 +214,12 @@ class DiaryCreateViewController: PlainCustomBarViewController{
     }()
     
     var userProfile : String?
-    private lazy var profileImage : UIImageView = {
-        var view = UIImageView()
-        let profileImageUrl = URL(string: userProfile ?? "default image url")
-        // profileImage.kf.setImage(with: profileImageUrl)
-        // kingfisher no such module error
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
+    
+    private lazy var profileImage : SymbolCircleView = {
+        let imageView = SymbolCircleView(symbolImage: UIImage(systemName: "person.fill"))
+        imageView.setBackgroundColor(.secondarySystemFill)
+        imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        return imageView
     }()
     
     var userName : String?

--- a/watomate/Watomate/Sources/Profile/UI/ViewController/ProfileViewController.swift
+++ b/watomate/Watomate/Sources/Profile/UI/ViewController/ProfileViewController.swift
@@ -19,6 +19,15 @@ class ProfileViewController: TodoTableViewController {
         return label
     }()
     
+    override init(todoListViewModel: TodoListViewModel) {
+        super.init(todoListViewModel: todoListViewModel)
+        self.todoListViewModel.delegate = self
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         todoTableView.register(ProfileHeaderView.self, forHeaderFooterViewReuseIdentifier: ProfileHeaderView.reuseIdentifier)
         super.viewDidLoad()
@@ -76,6 +85,33 @@ class ProfileViewController: TodoTableViewController {
             return 131.6667
         }
         return 60
+    }
+}
+
+extension ProfileViewController: TodoListViewModelDelegate {
+    
+    func todoListViewModel(_ viewModel: TodoListViewModel, didInsertCellViewModel todoViewModel: TodoCellViewModel, at indexPath: IndexPath) {
+        Task { @MainActor in
+            if let cell = todoTableView.cellForRow(at: indexPath) as? TodoCell {
+                cell.titleBecomeFirstResponder()
+                todoTableView.scrollToRow(at: indexPath, at: .middle, animated: true)
+            }
+    //        updateUnavailableView()
+        }
+    }
+
+    func todoListViewModel(_ viewModel: TodoListViewModel, didRemoveCellViewModel todoViewModel: TodoCellViewModel, at indexPath: IndexPath, options: ReloadOptions) {
+        if options.contains(.reload) {
+            let animated = options.contains(.animated)
+            todoTableView.deleteRows(at: [indexPath], with: animated ? .automatic : .none)
+        }
+//        updateUnavailableView()
+    }
+    
+    func todoListViewModel(_ viewModel: TodoListViewModel, showDetailViewWith cellViewModel: TodoCellViewModel) {
+        let vc = TodoDetailViewController(viewModel: cellViewModel)
+        vc.delegate = self
+        present(vc, animated: true)
     }
 }
 

--- a/watomate/Watomate/Sources/Profile/UI/ViewController/ProfileViewController.swift
+++ b/watomate/Watomate/Sources/Profile/UI/ViewController/ProfileViewController.swift
@@ -10,29 +10,7 @@ import UIKit
 import SnapKit
 import Combine
 
-class ProfileViewController: UIViewController {
-    
-    typealias DataSource = UITableViewDiffableDataSource<Int, TodoCellViewModel>
-    typealias Snapshot = NSDiffableDataSourceSnapshot<Int, TodoCellViewModel>
-    
-    var dataSource: DataSource!
-    var snapshot: Snapshot!
-    
-    private let todoListViewModel : TodoListViewModel
-    
-    private let input = PassthroughSubject<TodoListViewModel.Input, Never>()
-    private var cancellables = Set<AnyCancellable>()
-    private var viewModelCancellables: AnyCancellable?
-    
-    init(todoListViewModel: TodoListViewModel) {
-        self.todoListViewModel = todoListViewModel
-        super.init(nibName: nil, bundle: nil)
-        self.todoListViewModel.delegate = self
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+class ProfileViewController: TodoTableViewController {
     
     private var usernameLabel = {
         let label = UILabel()
@@ -41,35 +19,9 @@ class ProfileViewController: UIViewController {
         return label
     }()
     
-    private lazy var todoTableView = {
-        let tableView = UITableView(frame: .init(), style: .grouped)
-        tableView.translatesAutoresizingMaskIntoConstraints = false
-        tableView.delegate = self
-        tableView.estimatedRowHeight = 50
-        tableView.rowHeight = UITableView.automaticDimension
-        tableView.keyboardDismissMode = .interactive
-        tableView.separatorStyle = .none
-        tableView.backgroundColor = .systemBackground
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleEmptyTableViewTap(_:)))
-        tableView.addGestureRecognizer(tapGesture)
-        return tableView
-    }()
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        input.send(.viewDidAppear)
-    }
-    
     override func viewDidLoad() {
-        super.viewDidLoad()
-        setupTopBarItems()
-        todoTableView.register(TodoHeaderView.self, forHeaderFooterViewReuseIdentifier: TodoHeaderView.reuseIdentifier)
         todoTableView.register(ProfileHeaderView.self, forHeaderFooterViewReuseIdentifier: ProfileHeaderView.reuseIdentifier)
-        registerCells()
-        setupLayout()
-        configureDataSource()
-        bindViewModel()
-        registerKeyboardNotification()
+        super.viewDidLoad()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -85,102 +37,12 @@ class ProfileViewController: UIViewController {
         usernameLabel.text = username
     }
     
-    private func setupLayout() {
-        view.addSubview(todoTableView)
-        todoTableView.snp.makeConstraints { make in
-            make.edges.equalTo(view.safeAreaLayoutGuide)
-        }
-    }
-    
-    func registerCells() {
-        todoTableView.register(TodoCell.self, forCellReuseIdentifier: TodoCell.reuseIdentifier)
-    }
-    
-    private func registerKeyboardNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(notification:)), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(notification:)), name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-    
-    @objc private func keyboardWillShow(notification: NSNotification) {
-        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-            todoTableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardSize.height, right: 0)
-            todoTableView.scrollIndicatorInsets = todoTableView.contentInset
-        }
-    }
-    
-    @objc private func keyboardWillHide(notification: NSNotification) {
-        todoTableView.contentInset = UIEdgeInsets.zero
-        todoTableView.scrollIndicatorInsets = UIEdgeInsets.zero
-    }
-    
-    deinit {
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-    
-    private func configureDataSource() {
-        dataSource = DataSource(tableView: todoTableView, cellProvider: { tableView, indexPath, itemIdentifier in
-            let cell = tableView.dequeueReusableCell(withIdentifier: TodoCell.reuseIdentifier, for: indexPath) as! TodoCell
-            cell.configure(with: itemIdentifier)
-            return cell
-        })
-    }
-    
-    private func bindViewModel() {
-        let output = todoListViewModel.transform(input: input.eraseToAnyPublisher())
-        output.receive(on: DispatchQueue.main)
-            .sink { [weak self] event in
-                switch event {
-                case .loadFailed(let errorMsg):
-                    print("error: \(errorMsg)")
-                }
-            }.store(in: &cancellables)
-
-        viewModelCancellables = todoListViewModel.vms
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] viewModels in
-                self?.applySnapshot(with: viewModels)
-            }
-    }
-    
-    private func applySnapshot(with viewModels: [Int: [TodoCellViewModel]]) {
-        self.snapshot = Snapshot()
-        let sections = Array(0...viewModels.count)
-        snapshot.appendSections(sections)
-        if viewModels.count == 0 {
-            return
-        }
-        for i in 0...viewModels.count - 1 {
-            guard let cellVMs = viewModels[i + 1] else { return }
-            snapshot.appendItems(cellVMs, toSection: i + 1)
-        }
-        todoTableView.reloadData()
-        self.dataSource.apply(snapshot, animatingDifferences: false)
-    }
-    
-    @objc private func handleEmptyTableViewTap(_ gesture: UITapGestureRecognizer) {
-        let location = gesture.location(in: todoTableView)
-        if location.y > todoTableView.contentSize.height {
-            print("need to generate new cell")
-//            let success = profileViewControllerViewModel.appendPlaceholderIfNeeded()
-//            if !success {
-//                todoTableView.endEditing(false)
-//            }
-        }
-    }
-    
     @objc private func settingButtonTapped() {
         let settingsViewController = SettingsViewController()
         navigationController?.pushViewController(settingsViewController, animated: true)
     }
-}
-
-extension ProfileViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        return nil
-    }
     
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         if section == 0 {
             guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: ProfileHeaderView.reuseIdentifier) as? ProfileHeaderView else { return nil }
             header.contentView.backgroundColor = .systemBackground
@@ -209,57 +71,11 @@ extension ProfileViewController: UITableViewDelegate {
         navigationController?.pushViewController(viewController, animated: true)
     }
     
-    @objc private func addEmptyTodo(_ sender: UITapGestureRecognizer) {
-        guard let headerView = sender.view as? GoalStackView else { return }
-            
-        let section = headerView.tag
-        let success = todoListViewModel.appendPlaceholderIfNeeded(at: section)
-        if !success {
-            todoTableView.endEditing(false)
-        }
-    }
-    
-    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+    override func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
         if section == 0 {
             return 131.6667
         }
         return 60
-    }
-    
-    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        let view = UIView()
-        view.backgroundColor = .systemBackground
-        return view
-    }
-}
-
-extension ProfileViewController: TodoListViewModelDelegate {
-    
-    func todoListViewModel(_ viewModel: TodoListViewModel, didInsertCellViewModel todoViewModel: TodoCellViewModel, at indexPath: IndexPath) {
-        Task { @MainActor in
-            if let cell = todoTableView.cellForRow(at: indexPath) as? TodoCell {
-                cell.titleBecomeFirstResponder()
-                todoTableView.scrollToRow(at: indexPath, at: .middle, animated: true)
-            }
-    //        updateUnavailableView()
-        }
-    }
-
-    func todoListViewModel(_ viewModel: TodoListViewModel, didRemoveCellViewModel todoViewModel: TodoCellViewModel, at indexPath: IndexPath, options: ReloadOptions) {
-        if options.contains(.reload) {
-            let animated = options.contains(.animated)
-            todoTableView.deleteRows(at: [indexPath], with: animated ? .automatic : .none)
-        }
-//        updateUnavailableView()
-    }
-    
-    func todoListViewModel(_ viewModel: TodoListViewModel, showDetailViewWith cellViewModel: TodoCellViewModel) {
-        let vc = TodoDetailViewController(viewModel: cellViewModel)
-        vc.delegate = self
-//        vc.sheetPresentationController?.detents = [.custom(resolver: { context in
-//            return 600
-//        })]
-        present(vc, animated: true)
     }
 }
 
@@ -270,23 +86,5 @@ extension ProfileViewController: ProfileEditViewDelegate {
 //            headerView.setNeedsLayout()
 //            headerView.layoutIfNeeded()
         }
-    }
-}
-
-extension ProfileViewController: TodoDetailViewDelegate {
-    func deleteTodoCell(with viewModel: TodoCellViewModel) {
-        guard let indexPath = todoListViewModel.indexPath(with: viewModel.uuid) else { return }
-        self.todoListViewModel.remove(at: indexPath)
-    }
-    
-    func didEndEditingMemo(viewModel: TodoCellViewModel) {
-        let todo = Todo(uuid: viewModel.uuid, id: viewModel.id, title: viewModel.title, color: viewModel.color, description: viewModel.memo, isCompleted: viewModel.isCompleted, goal: viewModel.goal, likes: viewModel.likes)
-        todoListViewModel.todoCellViewModel(viewModel, didUpdateItem: todo)
-    }
-    
-    func editTitle(with viewModel: TodoCellViewModel) {
-        guard let indexPath = todoListViewModel.indexPath(with: viewModel.uuid) else { return }
-        let cell = todoTableView.cellForRow(at: indexPath) as! TodoCell
-        cell.canEditTitle()
     }
 }

--- a/watomate/Watomate/Sources/TabBarController.swift
+++ b/watomate/Watomate/Sources/TabBarController.swift
@@ -13,7 +13,11 @@ class TabBarController: UITabBarController {
         super.viewDidLoad()
         view.backgroundColor = UIColor.systemBackground
         
-        let todoVC = UINavigationController(rootViewController: ToDoViewController())
+        let todoRepository = TodoRepository()
+        let todoUseCase = TodoUseCase(todoRepository: todoRepository)
+        let todoListViewModel = TodoListViewModel(todoUseCase: todoUseCase)
+        
+        let todoVC = UINavigationController(rootViewController: HomeViewController(todoListViewModel: todoListViewModel))
         todoVC.tabBarItem = UITabBarItem(title: "Home", image: UIImage(systemName: "house.fill"), tag: 0)
 
         let searchVC = UINavigationController(rootViewController: SearchViewController())
@@ -23,9 +27,6 @@ class TabBarController: UITabBarController {
         let groupVC = UINavigationController(rootViewController: GroupViewController())
         groupVC.tabBarItem = UITabBarItem(title: "Group", image: UIImage(systemName: "rectangle.3.group.fill"), tag: 2)
 
-        let todoRepository = TodoRepository()
-        let todoUseCase = TodoUseCase(todoRepository: todoRepository)
-        let todoListViewModel = TodoListViewModel(todoUseCase: todoUseCase)
         let profileVC = UINavigationController(rootViewController: ProfileViewController(todoListViewModel: todoListViewModel))
 
         profileVC.tabBarItem = UITabBarItem(title: "Profile", image: UIImage(systemName: "person.crop.circle.fill"), tag: 3)

--- a/watomate/Watomate/Sources/TabBarController.swift
+++ b/watomate/Watomate/Sources/TabBarController.swift
@@ -16,8 +16,9 @@ class TabBarController: UITabBarController {
         let todoRepository = TodoRepository()
         let todoUseCase = TodoUseCase(todoRepository: todoRepository)
         let todoListViewModel = TodoListViewModel(todoUseCase: todoUseCase)
+        let diaryViewModel = DiaryPreviewViewModel()
         
-        let todoVC = UINavigationController(rootViewController: HomeViewController(todoListViewModel: todoListViewModel))
+        let todoVC = UINavigationController(rootViewController: HomeViewController(todoListViewModel: todoListViewModel, diaryViewModel: diaryViewModel))
         todoVC.tabBarItem = UITabBarItem(title: "Home", image: UIImage(systemName: "house.fill"), tag: 0)
 
         let searchVC = UINavigationController(rootViewController: SearchViewController())

--- a/watomate/Watomate/Sources/TodoTableViewController.swift
+++ b/watomate/Watomate/Sources/TodoTableViewController.swift
@@ -7,24 +7,227 @@
 //
 
 import UIKit
+import SnapKit
+import Combine
 
 class TodoTableViewController: UIViewController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+    
+    typealias DataSource = UITableViewDiffableDataSource<Int, TodoCellViewModel>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<Int, TodoCellViewModel>
+    
+    var dataSource: DataSource!
+    var snapshot: Snapshot!
+    
+    internal let todoListViewModel : TodoListViewModel
+    
+    internal let input = PassthroughSubject<TodoListViewModel.Input, Never>()
+    internal var cancellables = Set<AnyCancellable>()
+    internal var viewModelCancellables: AnyCancellable?
+    
+    init(todoListViewModel: TodoListViewModel) {
+        self.todoListViewModel = todoListViewModel
+        super.init(nibName: nil, bundle: nil)
+        self.todoListViewModel.delegate = self
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
-    */
+    
+    internal lazy var todoTableView = {
+        let tableView = UITableView(frame: .init(), style: .grouped)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.delegate = self
+        tableView.estimatedRowHeight = 50
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.keyboardDismissMode = .interactive
+        tableView.separatorStyle = .none
+        tableView.backgroundColor = .systemBackground
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleEmptyTableViewTap(_:)))
+        tableView.addGestureRecognizer(tapGesture)
+        return tableView
+    }()
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        input.send(.viewDidAppear)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        todoTableView.register(TodoHeaderView.self, forHeaderFooterViewReuseIdentifier: TodoHeaderView.reuseIdentifier)
+        registerCells()
+        setupLayout()
+        configureDataSource()
+        bindViewModel()
+        registerKeyboardNotification()
+    }
+    
+    internal func setupLayout() {
+        view.addSubview(todoTableView)
+        todoTableView.snp.makeConstraints { make in
+            make.edges.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+    
+    func registerCells() {
+        todoTableView.register(TodoCell.self, forCellReuseIdentifier: TodoCell.reuseIdentifier)
+    }
+    
+    private func registerKeyboardNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(notification:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(notification:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc private func keyboardWillShow(notification: NSNotification) {
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            todoTableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardSize.height, right: 0)
+            todoTableView.scrollIndicatorInsets = todoTableView.contentInset
+        }
+    }
+    
+    @objc private func keyboardWillHide(notification: NSNotification) {
+        todoTableView.contentInset = UIEdgeInsets.zero
+        todoTableView.scrollIndicatorInsets = UIEdgeInsets.zero
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    private func configureDataSource() {
+        dataSource = DataSource(tableView: todoTableView, cellProvider: { tableView, indexPath, itemIdentifier in
+            let cell = tableView.dequeueReusableCell(withIdentifier: TodoCell.reuseIdentifier, for: indexPath) as! TodoCell
+            cell.configure(with: itemIdentifier)
+            return cell
+        })
+    }
+    
+    private func bindViewModel() {
+        let output = todoListViewModel.transform(input: input.eraseToAnyPublisher())
+        output.receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                switch event {
+                case .loadFailed(let errorMsg):
+                    print("error: \(errorMsg)")
+                }
+            }.store(in: &cancellables)
 
+        viewModelCancellables = todoListViewModel.vms
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] viewModels in
+                self?.applySnapshot(with: viewModels)
+            }
+    }
+    
+    private func applySnapshot(with viewModels: [Int: [TodoCellViewModel]]) {
+        self.snapshot = Snapshot()
+        let sections = Array(0...viewModels.count)
+        snapshot.appendSections(sections)
+        if viewModels.count == 0 {
+            return
+        }
+        for i in 0...viewModels.count - 1 {
+            guard let cellVMs = viewModels[i + 1] else { return }
+            snapshot.appendItems(cellVMs, toSection: i + 1)
+        }
+        todoTableView.reloadData()
+        self.dataSource.apply(snapshot, animatingDifferences: false)
+    }
+    
+    @objc private func handleEmptyTableViewTap(_ gesture: UITapGestureRecognizer) {
+        let location = gesture.location(in: todoTableView)
+        if location.y > todoTableView.contentSize.height {
+        }
+    }
+}
+
+extension TodoTableViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        return nil
+    }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        if section == 0 {
+            let header = UITableViewHeaderFooterView()
+            return header
+        }
+        
+        guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TodoHeaderView.reuseIdentifier) as? TodoHeaderView else { return nil }
+        header.goalView.tag = section
+        header.setTitle(with: todoListViewModel.getTitle(of: section))
+        header.setColor(with: todoListViewModel.getColor(of: section))
+        header.setVisibility(with: todoListViewModel.getVisibility(of: section))
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(addEmptyTodo))
+        header.goalView.addGestureRecognizer(tapGesture)
+        header.goalView.isUserInteractionEnabled = true
+        header.contentView.backgroundColor = .systemBackground
+        return header
+    }
+    
+    @objc internal func addEmptyTodo(_ sender: UITapGestureRecognizer) {
+        guard let headerView = sender.view as? GoalStackView else { return }
+            
+        let section = headerView.tag
+        let success = todoListViewModel.appendPlaceholderIfNeeded(at: section)
+        if !success {
+            todoTableView.endEditing(false)
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        return 60
+    }
+    
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        let view = UIView()
+        view.backgroundColor = .systemBackground
+        return view
+    }
+}
+
+extension TodoTableViewController: TodoListViewModelDelegate {
+    
+    func todoListViewModel(_ viewModel: TodoListViewModel, didInsertCellViewModel todoViewModel: TodoCellViewModel, at indexPath: IndexPath) {
+        Task { @MainActor in
+            if let cell = todoTableView.cellForRow(at: indexPath) as? TodoCell {
+                cell.titleBecomeFirstResponder()
+                todoTableView.scrollToRow(at: indexPath, at: .middle, animated: true)
+            }
+    //        updateUnavailableView()
+        }
+    }
+
+    func todoListViewModel(_ viewModel: TodoListViewModel, didRemoveCellViewModel todoViewModel: TodoCellViewModel, at indexPath: IndexPath, options: ReloadOptions) {
+        if options.contains(.reload) {
+            let animated = options.contains(.animated)
+            todoTableView.deleteRows(at: [indexPath], with: animated ? .automatic : .none)
+        }
+//        updateUnavailableView()
+    }
+    
+    func todoListViewModel(_ viewModel: TodoListViewModel, showDetailViewWith cellViewModel: TodoCellViewModel) {
+        let vc = TodoDetailViewController(viewModel: cellViewModel)
+        vc.delegate = self
+        present(vc, animated: true)
+    }
+}
+
+extension TodoTableViewController: TodoDetailViewDelegate {
+    func deleteTodoCell(with viewModel: TodoCellViewModel) {
+        guard let indexPath = todoListViewModel.indexPath(with: viewModel.uuid) else { return }
+        self.todoListViewModel.remove(at: indexPath)
+    }
+    
+    func didEndEditingMemo(viewModel: TodoCellViewModel) {
+        let todo = Todo(uuid: viewModel.uuid, id: viewModel.id, title: viewModel.title, color: viewModel.color, description: viewModel.memo, isCompleted: viewModel.isCompleted, goal: viewModel.goal, likes: viewModel.likes)
+        todoListViewModel.todoCellViewModel(viewModel, didUpdateItem: todo)
+    }
+    
+    func editTitle(with viewModel: TodoCellViewModel) {
+        guard let indexPath = todoListViewModel.indexPath(with: viewModel.uuid) else { return }
+        let cell = todoTableView.cellForRow(at: indexPath) as! TodoCell
+        cell.canEditTitle()
+    }
 }

--- a/watomate/Watomate/Sources/TodoTableViewController.swift
+++ b/watomate/Watomate/Sources/TodoTableViewController.swift
@@ -27,7 +27,6 @@ class TodoTableViewController: UIViewController {
     init(todoListViewModel: TodoListViewModel) {
         self.todoListViewModel = todoListViewModel
         super.init(nibName: nil, bundle: nil)
-        self.todoListViewModel.delegate = self
     }
     
     required init?(coder: NSCoder) {
@@ -184,33 +183,6 @@ extension TodoTableViewController: UITableViewDelegate {
         let view = UIView()
         view.backgroundColor = .systemBackground
         return view
-    }
-}
-
-extension TodoTableViewController: TodoListViewModelDelegate {
-    
-    func todoListViewModel(_ viewModel: TodoListViewModel, didInsertCellViewModel todoViewModel: TodoCellViewModel, at indexPath: IndexPath) {
-        Task { @MainActor in
-            if let cell = todoTableView.cellForRow(at: indexPath) as? TodoCell {
-                cell.titleBecomeFirstResponder()
-                todoTableView.scrollToRow(at: indexPath, at: .middle, animated: true)
-            }
-    //        updateUnavailableView()
-        }
-    }
-
-    func todoListViewModel(_ viewModel: TodoListViewModel, didRemoveCellViewModel todoViewModel: TodoCellViewModel, at indexPath: IndexPath, options: ReloadOptions) {
-        if options.contains(.reload) {
-            let animated = options.contains(.animated)
-            todoTableView.deleteRows(at: [indexPath], with: animated ? .automatic : .none)
-        }
-//        updateUnavailableView()
-    }
-    
-    func todoListViewModel(_ viewModel: TodoListViewModel, showDetailViewWith cellViewModel: TodoCellViewModel) {
-        let vc = TodoDetailViewController(viewModel: cellViewModel)
-        vc.delegate = self
-        present(vc, animated: true)
     }
 }
 

--- a/watomate/Watomate/Sources/TodoTableViewController.swift
+++ b/watomate/Watomate/Sources/TodoTableViewController.swift
@@ -1,0 +1,30 @@
+//
+//  TodoTableViewController.swift
+//  Watomate
+//
+//  Created by 권현구 on 1/30/24.
+//  Copyright © 2024 tuist.io. All rights reserved.
+//
+
+import UIKit
+
+class TodoTableViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}


### PR DESCRIPTION
### 변경사항
- ToDoViewController -> HomeViewController로 대체 + viewModel dependency injection 적용
- HomeViewController, ProfileViewController -> TodoTableViewController를 상속받는 형태로 재사용성 높임
- HomeViewController
    - section 0의 헤더로 CalendarHeaderView만들어 사용
    - calenderView 가져다 쓰고싶다면 => HomeViewController에서 
    - `let headerView = tableView(todoTableView, viewForHeaderInSection: 0) as! CalendarHeaderView`
        `let calendarView = headerView.calendarView` 로 사용 가능
- HomeViewController와 DiaryCreateViewController의 UI layout을 스택뷰로 바꿈
- HomeVC와 ProfileVC에 동일한 ViewModel넣어서 한번에 연동(추가적으로 UI건드릴 필요없이 한쪽에서 업데이트하면 다른쪽에도 적용됨)

### 수정 필요
- 캘린더 날짜 선택 시 선택여부 활성화되는 건 옮기지 못했음
- 홈탭에서 팔로워들 프로필 표시와 테두리 업데이트 구현 필요

### 구현필요
- 목표관리