### PR TITLE
feat: 투두 디테일뷰 셀 숨김

### DIFF
--- a/watomate/Watomate/Sources/Profile/UI/TodoCell.swift
+++ b/watomate/Watomate/Sources/Profile/UI/TodoCell.swift
@@ -185,6 +185,7 @@ class TodoCell: UITableViewCell {
         }
         memoStackView.isHidden = viewModel.isMemoHidden
         configureCheckbox(isComplete: viewModel.isCompleted)
+        checkbox.isUserInteractionEnabled = viewModel.date != nil
     }
 
     @objc private func showBottomSheetView() {

--- a/watomate/Watomate/Sources/Profile/UI/ViewController/TodoDetailViewController.swift
+++ b/watomate/Watomate/Sources/Profile/UI/ViewController/TodoDetailViewController.swift
@@ -241,6 +241,7 @@ class TodoDetailViewController: SheetCustomViewController {
         verificationCell.isHidden = !viewModel.isCompleted
         editTitleButton.addTarget(self, action: #selector(handleEditBtnTap), for: .touchUpInside)
         deleteTodoButton.addTarget(self, action: #selector(handleDeleteBtnTap), for: .touchUpInside)
+        moveToArchiveCell.isHidden = viewModel.date == nil
     }
     
     func toggleReminderEditView() {


### PR DESCRIPTION
### 변경 사항
- 프로필 탭에서 투두 완료 불가능
- 프로필 탭에서는 '보관함으로 이동' 버튼 숨김